### PR TITLE
Fix broken link to Lock-up folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All logo versions are available in Adobe Illustrator (`.ai`), Encapsulated PostS
   <img alt="Crown" src="Logo/Crown/Black/Crown_Black.svg" height="150">
 </picture>
 
-### [Lockup](Logo/Lockup)
+### [Lock-up](Logo/Lock-up)
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="Logo/Lock-up/Primary%20White/Lock-up_PrimaryWhite.svg">


### PR DESCRIPTION
The link from the readme to the Lock-up folder was broken because the folder name contains a hyphen. I've added the hyphen to the link text as well so it's consisent with the folder name and the brand guidelines:

<img width="448" height="213" alt="Lock-up. To aid recognition the lock-up combines the crown and wordmark and is used primarily within the web channel." src="https://github.com/user-attachments/assets/16e3d659-3cd3-4ee8-8549-1a5b647542ef" />
